### PR TITLE
Resolve minor issues with satellite template

### DIFF
--- a/workflow-templates/cfgov-python-satellite-ci.yml
+++ b/workflow-templates/cfgov-python-satellite-ci.yml
@@ -1,6 +1,11 @@
 name: Python CI workflow
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
 
 jobs:
   backend:
@@ -10,8 +15,8 @@ jobs:
       matrix:
         # Add the appropriate Tox environments for the satellite here
         toxenv:
-            - py36
-            - py38
+            - py36-dj22
+            - py38-dj22
         include:
           # Adjust the Python versions required for the tox environments as 
           # needed
@@ -22,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v1

--- a/workflow-templates/cfgov-python-satellite-release.yml
+++ b/workflow-templates/cfgov-python-satellite-release.yml
@@ -10,7 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # If the package has a front-end build we need to set up and install 
       # Node and other dependencies

--- a/workflow-templates/cfpb-pypi-publish.yml
+++ b/workflow-templates/cfpb-pypi-publish.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v1

--- a/workflow-templates/cfpb-python-library-ci.yml
+++ b/workflow-templates/cfpb-python-library-ci.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v1


### PR DESCRIPTION
Couple bugs with our current satellite template.

It runs on every commit pushed and all PR's so the tests run twice, now it will only run on commits to main/master.
It doesn't properly map tox-env to the python version, so updating the keys so they match.
It currently fails with tox, as it needs tags as part of our cfpb-setup, so now it clones the repo with all tags.