### PR TITLE
Only run cfpb-python-library-ci on pushes if branch is master or main

### DIFF
--- a/workflow-templates/cfpb-python-library-ci.yml
+++ b/workflow-templates/cfpb-python-library-ci.yml
@@ -1,6 +1,11 @@
 name: Python CI workflow
 
-on: [pull_request, push]
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
 
 jobs:
   backend:


### PR DESCRIPTION
Matching change we made to the satellite app job.